### PR TITLE
Add Countdown Calendar GA4 reporting

### DIFF
--- a/google-analytics.js
+++ b/google-analytics.js
@@ -1,0 +1,19 @@
+// @ts-check
+
+(() => {
+  const GOOGLE_ANALYTICS_MEASUREMENT_ID = "G-V4F5P3W6GH";
+  const analyticsWindow = /** @type {Window & {dataLayer?: unknown[][], gtag?: (...args: unknown[]) => void}} */ (window);
+  const dataLayer = analyticsWindow.dataLayer || [];
+
+  analyticsWindow.dataLayer = dataLayer;
+  analyticsWindow.gtag = function gtag(...args) {
+    dataLayer.push(args);
+  };
+  analyticsWindow.gtag("js", new Date());
+  analyticsWindow.gtag("config", GOOGLE_ANALYTICS_MEASUREMENT_ID);
+
+  const googleTag = document.createElement("script");
+  googleTag.async = true;
+  googleTag.src = `https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(GOOGLE_ANALYTICS_MEASUREMENT_ID)}`;
+  document.head.append(googleTag);
+})();

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8" />
     <title>Countdown Calendar</title>
+    <script defer src="/google-analytics.js"></script>
     <script src="https://accounts.google.com/gsi/client" async defer></script>
     <script src="https://unpkg.com/vue@3/dist/vue.global.js"></script>
     <style>


### PR DESCRIPTION
## Summary

- add a first-party GA4 loader for G-V4F5P3W6GH
- include it on the published Countdown Calendar page

## Validation

- loader syntax check passed
- browser request harness confirmed the exact gtag request and queued js/config events

No production deployment is included.